### PR TITLE
Pin pnpm version for lockfile compatibility

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,5 @@
 {
   "name": "Home Assistant Add-on: Tepco2MQTT",
-  "url": "https://github.com/aurimasniekis/hassio-tepco2mqtt",
+  "url": "https://github.com/quadcube/hassio-tepco2mqtt",
   "maintainer": "Aurimas Niekis <aurimas@niekis.lt>"
 }

--- a/tepco2mqtt/Dockerfile
+++ b/tepco2mqtt/Dockerfile
@@ -19,7 +19,7 @@ ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD 1
 ENV PUPPETEER_EXECUTABLE_PATH /usr/bin/chromium-browser
 
 RUN apk add --no-cache --virtual .buildtools npm make gcc g++ linux-headers udev git python3 && \
-    npm install -g pnpm && \
+    npm install -g pnpm@8 && \
     jq -n --arg commit $(eval git rev-parse --short HEAD) '$commit' > /app/.hash ; \
     echo "Installed Tepco2MQTT @ version $(cat /app/.hash)" && \
     cd /app && \

--- a/tepco2mqtt/config.json
+++ b/tepco2mqtt/config.json
@@ -1,9 +1,9 @@
 {
   "name": "Tepco2MQTT",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "slug": "tepco2mqtt",
   "description": "Tepco2MQTT is a Home Assistant add-on that automates data extraction from the TEPCO (Tokyo Electric Power Company) website using a headless Chromium browser. It seamlessly navigates the website, retrieves essential data, and publishes it to an MQTT broker, enabling easy integration with your Home Assistant setup.",
-  "url": "https://github.com/aurimasniekis/hassio-tepco2mqtt",
+  "url": "https://github.com/quadcube/hassio-tepco2mqtt",
   "startup": "application",
   "services": [
     "mqtt:need"

--- a/tepco2mqtt/package.json
+++ b/tepco2mqtt/package.json
@@ -5,7 +5,7 @@
   "version": "1.0.1",
   "license": "MIT",
   "author": "Aurimas Niekis <aurimas@niekis.lt>",
-  "homepage": "https://github.com/aurimasniekis/hassio-tepco2mqtt",
+  "homepage": "https://github.com/quadcube/hassio-tepco2mqtt",
   "contributors": [
     {
       "name": "Aurimas Niekis",
@@ -15,12 +15,12 @@
   ],
   "bugs": {
     "bugs": {
-      "url": "https://github.com/aurimasniekis/hassio-tepco2mqtt"
+      "url": "https://github.com/quadcube/hassio-tepco2mqtt"
     }
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/aurimasniekis/hassio-tepco2mqtt.git"
+    "url": "git+https://github.com/quadcube/hassio-tepco2mqtt.git"
   },
   "scripts": {
     "start": "tsx src/bin/tepco2mqtt.ts",

--- a/tepco2mqtt/package.json
+++ b/tepco2mqtt/package.json
@@ -2,7 +2,7 @@
   "name": "tepco2mqtt",
   "description": "Tepco2MQTT is a Home Assistant add-on that automates data extraction from the TEPCO (Tokyo Electric Power Company) website using a headless Chromium browser. It seamlessly navigates the website, retrieves essential data, and publishes it to an MQTT broker, enabling easy integration with your Home Assistant setup.",
   "type": "module",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "author": "Aurimas Niekis <aurimas@niekis.lt>",
   "homepage": "https://github.com/aurimasniekis/hassio-tepco2mqtt",

--- a/tepco2mqtt/src/tepco.ts
+++ b/tepco2mqtt/src/tepco.ts
@@ -171,7 +171,7 @@ export class Tepco {
 
     try {
       await page.goto('https://www.app.kurashi.tepco.co.jp/', {
-        waitUntil: 'networkidle0',
+        waitUntil: 'domcontentloaded',
         timeout: seconds(settings.get().browser.timeout),
       });
     } catch (e: unknown) {
@@ -213,8 +213,8 @@ export class Tepco {
         logger.debug('Waiting for login to complete', NS);
 
         await Promise.all([
-          await page.locator('button[name="action"]').click(),
-          await page.waitForNavigation({
+          page.locator('button[name="action"]').click(),
+          page.waitForNavigation({
             timeout: seconds(settings.get().browser.timeout),
           }),
         ]);


### PR DESCRIPTION
Build fails on HAOS Core 2026.5.4, Supervisor 2026.05.1, Operating System 17.3 due to incompatible pnpm version.
Fixed pnpm to v8 since the lockfileVersion = 6.0.

Build works fine after fix on this HAOS version.
